### PR TITLE
fix(dialog): lock body scrollbar

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@embroider/addon-shim": "^1.8.3",
     "@floating-ui/dom": "^1.2.7",
+    "body-scroll-lock": "^4.0.0-beta.0",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "focus-trap": "^6.9.4"
@@ -48,6 +49,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@rollup/plugin-babel": "^5.3.1",
+    "@types/body-scroll-lock": "^3.1.0",
     "@types/ember__component": "^4.0.8",
     "@types/ember__destroyable": "^4.0.1",
     "@types/ember__object": "^4.0.2",
@@ -105,6 +107,7 @@
       "./helpers/or.js": "./dist/_app_/helpers/or.js",
       "./helpers/tag-is-component.js": "./dist/_app_/helpers/tag-is-component.js",
       "./modifiers/autofocus.js": "./dist/_app_/modifiers/autofocus.js",
+      "./modifiers/body-scroll-lock.js": "./dist/_app_/modifiers/body-scroll-lock.js",
       "./modifiers/focus-trap.js": "./dist/_app_/modifiers/focus-trap.js",
       "./modifiers/on-outside-interaction.js": "./dist/_app_/modifiers/on-outside-interaction.js",
       "./modifiers/velcro.js": "./dist/_app_/modifiers/velcro.js"

--- a/addon/src/components/dialog/panel.hbs
+++ b/addon/src/components/dialog/panel.hbs
@@ -2,11 +2,14 @@
   <Tag
     id={{@panelId}}
     tabindex="-1"
-    {{focus-trap options=(hash
-      fallbackFocus=(concat "#" @panelId)
-      allowOutsideClick=this.closeDialog
-      escapeDeactivates=this.closeDialog
-    )}}
+    {{focus-trap
+      options=(hash
+        fallbackFocus=(concat "#" @panelId)
+        allowOutsideClick=this.closeDialog
+        escapeDeactivates=this.closeDialog
+      )
+    }}
+    {{body-scroll-lock reserveScrollBarGap=true}}
     ...attributes
   >
     {{yield}}

--- a/addon/src/modifiers/body-scroll-lock.ts
+++ b/addon/src/modifiers/body-scroll-lock.ts
@@ -1,0 +1,21 @@
+import { modifier } from 'ember-modifier';
+import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
+import type { BodyScrollOptions } from 'body-scroll-lock';
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+    Named: BodyScrollOptions;
+  };
+}
+
+export default modifier<Signature>(
+  (element, _positional, options) => {
+    disableBodyScroll(element, options);
+
+    return () => {
+      enableBodyScroll(element);
+    };
+  },
+  { eager: false }
+);

--- a/test-app/app/index.html
+++ b/test-app/app/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Test app</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/test-app.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/test-app.css" />
 
     {{content-for "head-footer"}}
   </head>

--- a/test-app/app/router.js
+++ b/test-app/app/router.js
@@ -10,5 +10,6 @@ Router.map(function () {
   this.route('menu', function () {});
   this.route('dialog', function () {
     this.route('with-menu');
+    this.route('with-body-lock');
   });
 });

--- a/test-app/app/routes/dialog/with-body-lock.js
+++ b/test-app/app/routes/dialog/with-body-lock.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class DialogWithBodyLockRoute extends Route {}

--- a/test-app/app/templates/dialog/with-body-lock.hbs
+++ b/test-app/app/templates/dialog/with-body-lock.hbs
@@ -1,0 +1,13 @@
+{{! template-lint-disable no-inline-styles }}
+
+{{page-title "WithBodyLock"}}
+
+<div class="container" style="min-height: 120vh">
+  <MyDialog>
+    <div>
+      Dialog content!
+    </div>
+
+    <MyMenu />
+  </MyDialog>
+</div>

--- a/test-app/tests/unit/routes/dialog/with-body-lock-test.js
+++ b/test-app/tests/unit/routes/dialog/with-body-lock-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'test-app/tests/helpers';
+
+module('Unit | Route | dialog/with-body-lock', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:dialog/with-body-lock');
+    assert.ok(route);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,6 +1710,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/body-scroll-lock@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/body-scroll-lock/-/body-scroll-lock-3.1.0.tgz#435f6abf682bf58640e1c2ee5978320b891970e7"
+  integrity sha512-3owAC4iJub5WPqRhxd8INarF2bWeQq1yQHBgYhN0XLBJMpd5ED10RrJ3aKiAwlTyL5wK7RkBD4SZUQz2AAAMdA==
+
 "@types/broccoli-plugin@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/broccoli-plugin/-/broccoli-plugin-3.0.0.tgz#290fda2270c47a568edfd0cefab8bb840d8bb7b2"
@@ -3297,6 +3302,11 @@ body-parser@1.20.0:
     raw-body "2.5.1"
     type-is "~1.6.18"
     unpipe "1.0.0"
+
+body-scroll-lock@^4.0.0-beta.0:
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz#4f78789d10e6388115c0460cd6d7d4dd2bbc4f7e"
+  integrity sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==
 
 body@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
When the body has a scrollbar, we add `overflow: hidden` and set the right padding equal to the scrollbar's width.