### PR TITLE
feat(portal): allow portals to be disabled

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -105,6 +105,7 @@
       "./components/tab/panel.js": "./dist/_app_/components/tab/panel.js",
       "./helpers/dom.js": "./dist/_app_/helpers/dom.js",
       "./helpers/or.js": "./dist/_app_/helpers/or.js",
+      "./helpers/reverse-boolean.js": "./dist/_app_/helpers/reverse-boolean.js",
       "./helpers/tag-is-component.js": "./dist/_app_/helpers/tag-is-component.js",
       "./modifiers/autofocus.js": "./dist/_app_/modifiers/autofocus.js",
       "./modifiers/body-scroll-lock.js": "./dist/_app_/modifiers/body-scroll-lock.js",

--- a/addon/src/components/menu/items.hbs
+++ b/addon/src/components/menu/items.hbs
@@ -1,7 +1,7 @@
 {{! template-lint-disable no-down-event-binding }}
 
 {{#if @isOpen}}
-  <Portal>
+  <Portal @disabled={{reverse-boolean @portal}}>
     {{#let (element (or @as "div")) as |Tag|}}
       <Tag
         id={{@itemsId}}

--- a/addon/src/components/portal.hbs
+++ b/addon/src/components/portal.hbs
@@ -1,3 +1,7 @@
-{{#in-element this.portalRoot insertBefore=null}}
+{{#if @disabled}}
   {{yield}}
-{{/in-element}}
+{{else}}
+  {{#in-element this.portalRoot insertBefore=null}}
+    {{yield}}
+  {{/in-element}}
+{{/if}}

--- a/addon/src/helpers/reverse-boolean.ts
+++ b/addon/src/helpers/reverse-boolean.ts
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+function reverseBoolean([value]: [unknown]) {
+  return typeof value === 'boolean' ? !value : value;
+}
+
+export default helper(reverseBoolean);

--- a/test-app/tests/integration/components/menu-test.js
+++ b/test-app/tests/integration/components/menu-test.js
@@ -379,6 +379,40 @@ module('Integration | Component | menu', function (hooks) {
     });
   });
 
+  test('portals by default', async function (assert) {
+    await render(hbs`
+      <div data-test-container>
+        <Menu as |menu|>
+          <menu.Button data-test-button>Toggle menu</menu.Button>
+          <menu.Items data-test-items>
+            <menu.Item>Item 1</menu.Item>
+          </menu.Items>
+        </Menu>
+      </div>
+    `);
+
+    await click('[data-test-button]');
+    assert.dom('[data-test-items]').isVisible();
+    assert.dom('[data-test-container]').doesNotIncludeText('Item 1');
+  });
+
+  test('portal can be disabled', async function (assert) {
+    await render(hbs`
+      <div data-test-container>
+        <Menu as |menu|>
+          <menu.Button data-test-button>Toggle menu</menu.Button>
+          <menu.Items @portal={{false}} data-test-items>
+            <menu.Item>Item 1</menu.Item>
+          </menu.Items>
+        </Menu>
+      </div>
+    `);
+
+    await click('[data-test-button]');
+    assert.dom('[data-test-items]').isVisible();
+    assert.dom('[data-test-container]').includesText('Item 1');
+  });
+
   test('can pass LinkTo component on the item', async function (assert) {
     await render(hbs`
       <Menu as |menu|>

--- a/test-app/tests/integration/components/portal-test.js
+++ b/test-app/tests/integration/components/portal-test.js
@@ -18,4 +18,15 @@ module('Integration | Component | portal', function (hooks) {
     assert.dom('[data-test-wrapper]').doesNotContainText('Outside');
     assert.dom(document.body).containsText('Outside');
   });
+
+  test('does not disrupt heirarchy if disabled', async function (assert) {
+    await render(hbs`
+      <div data-test-wrapper>
+        <div>Inside</div>
+        <Portal @disabled={{true}}>Outside</Portal>
+      </div>
+    `);
+
+    assert.dom('[data-test-wrapper]').includesText('Outside');
+  });
 });


### PR DESCRIPTION
## Changes
- `Portal` component accepts the `@disabled` boolean attribute (`false` by default).
- `menu.Items` component accepts the `@portal` boolean attribute (`true` by default).