### PR TITLE
remove(dialog): `@open` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Move `aria-modal`, `role`, and `aria-labelledby` property to `dialog.Panel` component.
 
+### Removed
+- `Dialog` no longer accepts the `@open` argument.
+
 ## [0.3.0] - 2023-05-08
 
 ### Added

--- a/addon/src/components/dialog.hbs
+++ b/addon/src/components/dialog.hbs
@@ -1,18 +1,16 @@
 {{! template-lint-disable no-down-event-binding }}
 
-{{#if @open}}
-  <Portal>
-    {{#let (element (or @as "div")) as |Tag|}}
-      <Tag ...attributes {{on "keydown" this.handleKeydown}}>
-        {{yield
-          (hash
-            Title=(component
-              "dialog/title" titleId=this.titleId registerTitle=this.registerTitle unregisterTitle=this.unregisterTitle
-            )
-            Panel=(component "dialog/panel" panelId=this.panelId title=this.title titleId=this.titleId onClose=@onClose)
+<Portal>
+  {{#let (element (or @as "div")) as |Tag|}}
+    <Tag ...attributes {{on "keydown" this.handleKeydown}}>
+      {{yield
+        (hash
+          Title=(component
+            "dialog/title" titleId=this.titleId registerTitle=this.registerTitle unregisterTitle=this.unregisterTitle
           )
-        }}
-      </Tag>
-    {{/let}}
-  </Portal>
-{{/if}}
+          Panel=(component "dialog/panel" panelId=this.panelId title=this.title titleId=this.titleId onClose=@onClose)
+        )
+      }}
+    </Tag>
+  {{/let}}
+</Portal>

--- a/addon/src/components/dialog.ts
+++ b/addon/src/components/dialog.ts
@@ -5,7 +5,6 @@ import { action } from '@ember/object';
 import type DialogTitleComponent from './dialog/title';
 
 interface Args {
-  open: boolean;
   onClose: () => void;
 }
 

--- a/docs/docs/components/dialog.md
+++ b/docs/docs/components/dialog.md
@@ -15,6 +15,10 @@ import { action } from '@ember/object';
 export default class MyDialogComponent extends Component {
   @tracked isOpen = true;
 
+  @action open() {
+    this.isOpen = true;
+  }
+
   @action close() {
     this.isOpen = false;
   }
@@ -22,13 +26,15 @@ export default class MyDialogComponent extends Component {
 ```
 
 ```hbs
-<Dialog @open={{this.isOpen}} @onClose={{this.close}} as |dialog|>
-  <dialog.Panel>
-    <dialog.Title>Activate your account</dialog.Title>
-    <p>All your data will be restored.</p>
-    <button type="button">Button</button>
-  </dialog.Panel>
-</Dialog>
+<button type="button" {{on "click" this.open}}>Open dialog</button>
+{{#if this.isOpen}}
+  <Dialog @onClose={{this.close}} as |dialog|>
+    <dialog.Panel>
+      <dialog.Title>Activate your account</dialog.Title>
+      <p>All your data will be restored.</p>
+    </dialog.Panel>
+  </Dialog>
+{{/if}}
 ```
 
 > If you use the `dialog.Title` component, we will automatically set the `aria-labelledby` attribute on the `Dialog` component.
@@ -43,7 +49,7 @@ first focusable element, set `data-autofocus` on an element.
 Pressing `Tab` will cycle through all the focusable elements.
 
 ```diff
-<Dialog @open={{this.isOpen}} @onClose={{this.close}} as |dialog|>
+<Dialog @onClose={{this.close}} as |dialog|>
   <dialog.Panel>
     <dialog.Title>Activate your account</dialog.Title>
     <p>All your data will be restored.</p>
@@ -71,7 +77,6 @@ Pressing `Tab` will cycle through all the focusable elements.
 | Argument  | Default | Description                                                                |
 | ---       | ---     | ---                                                                        |
 | `as`      | `div`   | `string`                                                                   |
-| `open`    | -       | `Boolean`. Whether the dialog is open or not.                              |
 | `onClose` | -       | `() => void`. A function that will be called when the dialog is dismissed. |
 
 ### `dialog.Panel`

--- a/test-app/app/components/my-dialog.hbs
+++ b/test-app/app/components/my-dialog.hbs
@@ -2,13 +2,15 @@
   Open dialog
 </button>
 
-<Dialog @open={{this.isOpen}} @onClose={{this.close}} class="dialog" as |dialog|>
-  <dialog.Panel class="dialog-panel">
-    <header class="dialog-header">
-      <dialog.Title class="dialog-title">Dialog title</dialog.Title>
-      <button type="button" {{on "click" this.close}}>X</button>
-    </header>
+{{#if this.isOpen}}
+  <Dialog @onClose={{this.close}} class="dialog" as |dialog|>
+    <dialog.Panel class="dialog-panel">
+      <header class="dialog-header">
+        <dialog.Title class="dialog-title">Dialog title</dialog.Title>
+        <button type="button" {{on "click" this.close}}>X</button>
+      </header>
 
-    {{yield}}
-  </dialog.Panel>
-</Dialog>
+      {{yield}}
+    </dialog.Panel>
+  </Dialog>
+{{/if}}

--- a/test-app/tests/integration/components/dialog-test.js
+++ b/test-app/tests/integration/components/dialog-test.js
@@ -6,27 +6,11 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | dialog', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('does not render if @open={{false}}', async function (assert) {
-    this.set('onClose', function () {});
-
-    await render(hbs`
-      <Dialog data-test-dialog @open={{false}} @onClose={{this.onClose}} as |dialog|>
-        <dialog.Panel data-test-panel>
-          <dialog.Title data-test-title>
-            Dialog title
-          </dialog.Title>
-        </dialog.Panel>
-      </Dialog>
-    `);
-
-    assert.dom('[data-test-dialog]').isNotVisible();
-  });
-
   test('it renders without any errors', async function (assert) {
     this.set('onClose', function () {});
 
     await render(hbs`
-      <Dialog @open={{true}} @onClose={{this.onClose}} as |dialog|>
+      <Dialog @onClose={{this.onClose}} as |dialog|>
         <dialog.Panel data-test-panel>
           <dialog.Title data-test-title>
             Dialog title
@@ -45,7 +29,7 @@ module('Integration | Component | dialog', function (hooks) {
     this.set('onClose', function () {});
 
     await render(hbs`
-      <Dialog @open={{true}} @onClose={{this.onClose}} as |dialog|>
+      <Dialog @onClose={{this.onClose}} as |dialog|>
         <dialog.Panel role="alertdialog" data-test-panel>
           <dialog.Title data-test-title>
             Dialog title
@@ -62,7 +46,7 @@ module('Integration | Component | dialog', function (hooks) {
       this.set('onClose', function () {});
 
       await render(hbs`
-        <Dialog @open={{true}} @onClose={{this.onClose}} as |dialog|>
+        <Dialog @onClose={{this.onClose}} as |dialog|>
           <dialog.Panel data-test-panel>
             <dialog.Title data-test-title>
               Dialog title
@@ -78,7 +62,7 @@ module('Integration | Component | dialog', function (hooks) {
       this.set('onClose', function () {});
 
       await render(hbs`
-        <Dialog @open={{true}} @onClose={{this.onClose}} as |dialog|>
+        <Dialog @onClose={{this.onClose}} as |dialog|>
           <dialog.Panel data-test-panel></dialog.Panel>
         </Dialog>
       `);
@@ -97,9 +81,11 @@ module('Integration | Component | dialog', function (hooks) {
 
       await render(hbs`
         <button type="button" {{on "click" this.onOpen}}>Open dialog</button>
-        <Dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
-          <dialog.Panel data-test-panel></dialog.Panel>
-        </Dialog>
+        {{#if this.open}}
+          <Dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
+            <dialog.Panel data-test-panel></dialog.Panel>
+          </Dialog>
+        {{/if}}
       `);
 
       await click(find('button[type="button"]')); // open the dialog
@@ -117,11 +103,13 @@ module('Integration | Component | dialog', function (hooks) {
 
       await render(hbs`
         <button type="button" {{on "click" this.onOpen}}>Open dialog</button>
-        <Dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
-          <dialog.Panel data-test-panel>
-            <button data-test-button type="button" data-autofocus>Button</button>
-          </dialog.Panel>
-        </Dialog>
+        {{#if this.open}}
+          <Dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
+            <dialog.Panel data-test-panel>
+              <button data-test-button type="button" data-autofocus>Button</button>
+            </dialog.Panel>
+          </Dialog>
+        {{/if}}
       `);
 
       await click(find('button[type="button"]')); // open the dialog
@@ -139,11 +127,13 @@ module('Integration | Component | dialog', function (hooks) {
       });
 
       await render(hbs`
-        <Dialog data-test-dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
-          <dialog.Panel data-test-panel>
-            <button data-test-button type="button">Button</button>
-          </dialog.Panel>
-        </Dialog>
+        {{#if this.open}}
+          <Dialog data-test-dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
+            <dialog.Panel data-test-panel>
+              <button data-test-button type="button">Button</button>
+            </dialog.Panel>
+          </Dialog>
+        {{/if}}
       `);
 
       assert.dom('[data-test-dialog]').isVisible();
@@ -159,12 +149,14 @@ module('Integration | Component | dialog', function (hooks) {
       });
 
       await render(hbs`
-        <Dialog data-test-dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
-          <div data-inside>Inside</div>
-          <dialog.Panel data-test-panel>
-            <button data-test-button type="button">Button</button>
-          </dialog.Panel>
-        </Dialog>
+        {{#if this.open}}
+          <Dialog data-test-dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
+            <div data-inside>Inside</div>
+            <dialog.Panel data-test-panel>
+              <button data-test-button type="button">Button</button>
+            </dialog.Panel>
+          </Dialog>
+        {{/if}}
       `);
 
       assert.dom('[data-test-dialog]').isVisible();
@@ -180,11 +172,13 @@ module('Integration | Component | dialog', function (hooks) {
       });
 
       await render(hbs`
-        <Dialog data-test-dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
-          <dialog.Panel data-test-panel>
-            <button data-test-button type="button">Button</button>
-          </dialog.Panel>
-        </Dialog>
+        {{#if this.open}}
+          <Dialog data-test-dialog @open={{this.open}} @onClose={{this.onClose}} as |dialog|>
+            <dialog.Panel data-test-panel>
+              <button data-test-button type="button">Button</button>
+            </dialog.Panel>
+          </Dialog>
+        {{/if}}
       `);
 
       assert.dom('[data-test-dialog]').isVisible();


### PR DESCRIPTION
## Usage

```js
import Component from '@glimmer/component';
import { tracked } from '@glimmer/tracking';
import { action } from '@ember/object';

export default class MyDialogComponent extends Component {
  @tracked isOpen = true;

  @action open() {
    this.isOpen = true;
  }

  @action close() {
    this.isOpen = false;
  }
}
```

```hbs
<button type="button" {{on "click" this.open}}>Open dialog</button>
{{#if this.isOpen}}
  <Dialog @onClose={{this.close}} as |dialog|>
    <dialog.Panel>
      <dialog.Title>Activate your account</dialog.Title>
      <p>All your data will be restored.</p>
    </dialog.Panel>
  </Dialog>
{{/if}}
```

closes #36 